### PR TITLE
Add: actcast-app-base-python image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
           name: Build docker image
           command: make dist
       - store_artifacts:
-          path: actcast-rpi-app-base.tar.gz
+          path: dist
       - run:
           name: Release docker image
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,8 @@ workflows:
 jobs:
   build:
     <<: *defaults
+    environment:
+      DOCKER_BUILDKIT: 1
     steps:
       - checkout
       - setup_remote_docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,11 +2,8 @@ version: 2
 
 references:
   defaults: &defaults
-    docker:
-      - image: docker:stable-git
-        auth:
-          username: $DOCKER_USER
-          password: $DOCKER_PASS
+    machine:
+      image: ubuntu-2204:2022.04.2
     environment:
       TZ: "/usr/share/zoneinfo/Asia/Tokyo"
 
@@ -26,15 +23,13 @@ workflows:
 jobs:
   build:
     <<: *defaults
-    environment:
-      DOCKER_BUILDKIT: 1
     steps:
       - checkout
-      - setup_remote_docker:
-          version: 20.10.11
       - run:
           name: Install make
-          command: apk add make
+          command: |
+            sudo apt-get update
+            sudo apt-get install make
       - run:
           name: Login docker hub
           command: docker login -u ${DOCKER_USER} -p ${DOCKER_PASS}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,8 @@ jobs:
     <<: *defaults
     steps:
       - checkout
-      - setup_remote_docker
+      - setup_remote_docker:
+          version: 20.10.11
       - run:
           name: Install make
           command: apk add make

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,13 +26,18 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Setup docker
+          command: |
+            echo "$DOCKER_PASS" | docker login --username $DOCKER_USER --password-stdin
+            docker version
+            docker buildx create --use
+            docker buildx inspect --bootstrap
+            docker buildx ls
+      - run:
           name: Install make
           command: |
             sudo apt-get update
             sudo apt-get install make
-      - run:
-          name: Login docker hub
-          command: docker login -u ${DOCKER_USER} -p ${DOCKER_PASS}
       - run:
           name: Enable usermode emulation
           command: docker run --rm --privileged multiarch/qemu-user-static:register --reset

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
           command: docker run --rm --privileged multiarch/qemu-user-static:register --reset
       - run:
           name: Build docker image
-          command: make dist
+          command: make dist -j
       - store_artifacts:
           path: dist
       - run:

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /actcast-rpi-app-base.tar.gz
 /rootfs.tar.xz
 /actcast-rpi-app-base
+/actcast-rpi-app-base-python
 /actcast-rpi-app-builder
 
 # Created by https://www.gitignore.io/api/vim,osx,linux,emacs,windows

--- a/Dockerfile.python
+++ b/Dockerfile.python
@@ -1,0 +1,35 @@
+FROM --platform=linux/arm/v7 python:3.9.17-slim-buster as builder
+
+# Upgrade pip
+RUN python -m pip install --upgrade pip
+RUN apt update
+RUN apt install build-essential -y
+# Build numpy as a wheel
+RUN python -m pip wheel --wheel-dir=/root/wheels numpy 
+# Build pillow as a wheel
+RUN apt-get install -y libjpeg-dev libfreetype6-dev
+# actfw requires pillow<9.0.0,>=8.0.0
+RUN python -m pip wheel --wheel-dir=/root/wheels  'pillow<9.0.0,>=8.0.0' 
+
+RUN python -m pip install --no-index --find-links=/root/wheels numpy pillow
+
+# Stage 2: Final image
+FROM idein/actcast-rpi-app-base:buster-1
+
+# Set environment variable for Python
+ENV PATH /usr/local/bin:$PATH
+
+# python環境を引っこ抜いてくる （正しいやり方なのかあまり自信ない）
+COPY --from=builder /usr/local/lib/ /usr/local/lib/
+COPY --from=builder /usr/local/include/ /usr/local/include/
+COPY --from=builder /usr/local/bin/ /usr/local/bin/
+
+# RUNTIME dependency
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+     libexpat1 \
+     libfreetype6 libjpeg62-turbo \
+ && apt-get clean \
+ && apt-get autoclean \
+ && apt-get autoremove -y \
+ && rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/*

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 all: actcast-rpi-app-base-python
 
-dist: actcast-rpi-app-base.tar.gz
+dist: dist/actcast-rpi-app-base.tar.gz dist/actcast-rpi-app-base-python.tar.gz
 
 actcast-rpi-app-builder: Dockerfile.builder builder
 	docker build -f $< -t idein/$@ .
@@ -22,12 +22,13 @@ actcast-rpi-app-base: Dockerfile.base rootfs.tar.xz
 	docker build -f $< -t idein/$@ .
 	touch $@
 
-actcast-rpi-app-base.tar.gz: actcast-rpi-app-base
+dist/actcast-rpi-app-base.tar.gz dist/actcast-rpi-app-base-python.tar.gz: dist/%.tar.gz: %
+	mkdir -p $(dir $@)
 	docker save idein/$< | gzip > $@
 
 clean: clean-actcast-rpi-app-builder clean-actcast-rpi-app-base
 	-rm rootfs.tar.xz
-	-rm actcast-rpi-app-base.tar.gz
+	-rm -rf dist
 
 clean-actcast-rpi-app-builder:
 	-rm actcast-rpi-app-builder

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-all: actcast-rpi-app-base
+all: actcast-rpi-app-base-python
 
 dist: actcast-rpi-app-base.tar.gz
 
@@ -13,6 +13,10 @@ rootfs.tar.xz: actcast-rpi-app-builder
 	docker exec actcast-rpi-app-builder ./builder
 	docker cp actcast-rpi-app-builder:/root/rootfs.tar.xz .
 	-docker stop actcast-rpi-app-builder
+
+actcast-rpi-app-base-python: Dockerfile.python actcast-rpi-app-base
+	docker build -f $< -t idein/$@ .
+	touch $@
 
 actcast-rpi-app-base: Dockerfile.base rootfs.tar.xz
 	docker build -f $< -t idein/$@ .

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
+.PHONY: all
 all: actcast-rpi-app-base-python
 
+.PHONY: dist
 dist: dist/actcast-rpi-app-base.tar.gz dist/actcast-rpi-app-base-python.tar.gz
 
 actcast-rpi-app-builder: Dockerfile.builder builder
@@ -26,19 +28,23 @@ dist/actcast-rpi-app-base.tar.gz dist/actcast-rpi-app-base-python.tar.gz: dist/%
 	mkdir -p $(dir $@)
 	docker save idein/$< | gzip > $@
 
+.PHONY: clean
 clean: clean-actcast-rpi-app-builder clean-actcast-rpi-app-base clean-actcast-rpi-app-base-python
-	-rm rootfs.tar.xz
-	-rm -rf dist
+	-$(RM) rootfs.tar.xz
+	-$(RM) -r dist
 
+.PHONY: clean-actcast-rpi-app-builder
 clean-actcast-rpi-app-builder:
-	-rm actcast-rpi-app-builder
+	-$(RM) actcast-rpi-app-builder
 	-docker rmi idein/actcast-rpi-app-builder
 
+.PHONY: clean-actcast-rpi-app-base
 clean-actcast-rpi-app-base:
-	-rm actcast-rpi-app-base
+	-$(RM) actcast-rpi-app-base
 	-docker rmi idein/actcast-rpi-app-base
 
+.PHONY: clean-actcast-rpi-app-base-python
 clean-actcast-rpi-app-base-python:
-	-rm actcast-rpi-app-base-python
+	-$(RM) actcast-rpi-app-base-python
 	-docker rmi idein/actcast-rpi-app-base-python
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: all
-all: actcast-rpi-app-base-python
+all: actcast-rpi-app-base-python actcast-rpi-app-base
 
 .PHONY: dist
 dist: dist/actcast-rpi-app-base.tar.gz dist/actcast-rpi-app-base-python.tar.gz
@@ -16,8 +16,8 @@ rootfs.tar.xz: actcast-rpi-app-builder
 	docker cp actcast-rpi-app-builder:/root/rootfs.tar.xz .
 	-docker stop actcast-rpi-app-builder
 
-actcast-rpi-app-base-python: Dockerfile.python actcast-rpi-app-base
-	docker buildx build -f $< -t idein/$@ .
+actcast-rpi-app-base-python: Dockerfile.python
+	docker buildx build -f $< -t idein/$@ --load .
 	touch $@
 
 actcast-rpi-app-base: Dockerfile.base rootfs.tar.xz

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ rootfs.tar.xz: actcast-rpi-app-builder
 	-docker stop actcast-rpi-app-builder
 
 actcast-rpi-app-base-python: Dockerfile.python actcast-rpi-app-base
-	docker build -f $< -t idein/$@ .
+	docker buildx build -f $< -t idein/$@ .
 	touch $@
 
 actcast-rpi-app-base: Dockerfile.base rootfs.tar.xz

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ dist/actcast-rpi-app-base.tar.gz dist/actcast-rpi-app-base-python.tar.gz: dist/%
 	mkdir -p $(dir $@)
 	docker save idein/$< | gzip > $@
 
-clean: clean-actcast-rpi-app-builder clean-actcast-rpi-app-base
+clean: clean-actcast-rpi-app-builder clean-actcast-rpi-app-base clean-actcast-rpi-app-base-python
 	-rm rootfs.tar.xz
 	-rm -rf dist
 
@@ -37,3 +37,8 @@ clean-actcast-rpi-app-builder:
 clean-actcast-rpi-app-base:
 	-rm actcast-rpi-app-base
 	-docker rmi idein/actcast-rpi-app-base
+
+clean-actcast-rpi-app-base-python:
+	-rm actcast-rpi-app-base-python
+	-docker rmi idein/actcast-rpi-app-base-python
+

--- a/README.md
+++ b/README.md
@@ -1,5 +1,15 @@
 # Actcast Raspberry Pi アプリベースイメージ
 
+Actcast アプリケーションとして作成されるDockerイメージを作成する上で, ベースとなるイメージを提供します。
+
+## 種類
+
+`idein/actcast-rpi-app-base`
+: RaspberryPi用アプリ作成のための最低限の設定をしたイメージ
+
+`idein/actcast-rpi-app-base-python`
+: RaspberryPi用アプリ作成に必要な最低限の環境にpythonとnumpyとpillowを追加したイメージ
+
 ## Build
 
 dockerをインストールしてmultiarch対応させた上で，
@@ -8,13 +18,14 @@ dockerをインストールしてmultiarch対応させた上で，
 $ make
 ```
 
-すると，`idein/actcast-rpi-app-base` イメージが作成される．
+すると，`idein/actcast-rpi-app-base` イメージと `idein/actcast-rpi-app-base-python` イメージが作成される．
 
 ```console
 $ docker images idein/actcast-rpi-app-base
 REPOSITORY                   TAG        IMAGE ID       CREATED          SIZE
 idein/actcast-rpi-app-base   latest     4413af65372d   57 minutes ago   87.5MB
 ```
+
 
 ## Upgrade
 
@@ -30,7 +41,7 @@ builder:readonly RASPBIAN_VERSION=${RAPBIAN_VERSION:-[codename]}
 ## Release
 
 バージョンコードネームのタグを打ってpushするとCircleCI上でイメージがビルドされ，
-`idein/actcast-rpi-app-base:[codename]` としてhubにアップロードされる．
+`idein/actcast-rpi-app-base:[codename]` や `idein/actcast-rpi-app-base-python:[codename]` としてhubにアップロードされる．
 
 ```console
 $ git tag [codename]

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ builder:readonly RASPBIAN_VERSION=${RAPBIAN_VERSION:-[codename]}
 ## Release
 
 バージョンコードネームのタグを打ってpushするとCircleCI上でイメージがビルドされ，
-`idein/actcast-rpi-app-base:[codename]` や `idein/actcast-rpi-app-base-python:[codename]` としてhubにアップロードされる．
+`idein/actcast-rpi-app-base:[codename]` がhubにアップロードされる．
 
 ```console
 $ git tag [codename]

--- a/README.md
+++ b/README.md
@@ -21,9 +21,10 @@ $ make
 すると，`idein/actcast-rpi-app-base` イメージと `idein/actcast-rpi-app-base-python` イメージが作成される．
 
 ```console
-$ docker images idein/actcast-rpi-app-base
-REPOSITORY                   TAG        IMAGE ID       CREATED          SIZE
-idein/actcast-rpi-app-base   latest     4413af65372d   57 minutes ago   87.5MB
+$ docker images
+REPOSITORY                          TAG        IMAGE ID       CREATED          SIZE
+idein/actcast-rpi-app-base          latest     4413af65372d   57 minutes ago   87.5MB
+idein/actcast-rpi-app-base-python   latest     b5cd2eca6a3a   19 minutes ago   189MB
 ```
 
 


### PR DESCRIPTION
アプリ作成のベースイメージとして、あらかじめnumpy, pillowをインストールしたものを追加する。
追加するのはbuster由来のイメージなのでとりあえず(tagに基づく現在の)CIではpushしない。