### PR TITLE
add LD_LIBRARY_PATH for bullseye on buster

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -3,9 +3,10 @@ LABEL maintainer "notogawa <n.ohkawa@idein.jp>"
 
 ADD rootfs.tar.xz  /
 
-ENV LC_ALL C.UTF-8
-ENV PATH /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-ENV DEBIAN_FRONTEND noninteractive
+ENV LC_ALL=C.UTF-8
+ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+ENV LD_LIBRARY_PATH=/opt/vc/lib:${LD_LIBRARY_PATH}
+ENV DEBIAN_FRONTEND=noninteractive
 
 WORKDIR /root
 STOPSIGNAL SIGTERM


### PR DESCRIPTION
bullseye だと /opt/vc/lib をライブラリパスとして拾ってくれないので LD_LIBRARY_PATH 環境変数を設定します.
動作確認済です.