### PR TITLE
Fix docker image platform

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ actcast-rpi-app-base-python: Dockerfile.python
 
 actcast-rpi-app-base-$(FIRMWARE_TYPE): Dockerfile.base rootfs_$(FIRMWARE_TYPE).tar.xz
 	cp rootfs_$(FIRMWARE_TYPE).tar.xz rootfs.tar.xz
-	docker build -f $< -t idein/$@ .
+	docker build --platform=linux/arm/v7 -f $< -t idein/$@ .
 	touch $@
 
 dist/actcast-rpi-app-base-$(FIRMWARE_TYPE).tar.gz dist/actcast-rpi-app-base-python.tar.gz: dist/%.tar.gz: %


### PR DESCRIPTION
- PBI: [act の docker image manifest で platform として arm64 が指定されている問題の修正](https://www.notion.so/idein-inc/act-docker-image-manifest-platform-arm64-b37472f7866f46d08f87dc8f5df0badf?pvs=4)