### PR TITLE
Remove python3-libcamera from app-base

### DIFF
--- a/Dockerfile.bookworm
+++ b/Dockerfile.bookworm
@@ -41,7 +41,7 @@ RUN groupadd -f -g 20 dialout \
 
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   --mount=type=cache,target=/var/lib/apt,sharing=locked \
-  apt update && apt install --no-install-recommends -y libdrm2 python3-libcamera libatomic1
+  apt update && apt install --no-install-recommends -y libdrm2 libatomic1
 
 WORKDIR /root
 STOPSIGNAL SIGTERM


### PR DESCRIPTION
OS4向けのベースイメージから python3-libcamera を削除する